### PR TITLE
fix: aligned test suite to snakecaseing

### DIFF
--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -8,8 +8,8 @@ use Communibase\DataBag;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @author Kingsquare (source@kingsquare.nl)
- * @copyright Copyright (c) Kingsquare BV (http://www.kingsquare.nl)
+ * Class FactoryTest
+ * @package Communibase\Tests
  */
 class FactoryTest extends TestCase
 {

--- a/tests/GetFromDataBagTest.php
+++ b/tests/GetFromDataBagTest.php
@@ -16,6 +16,52 @@ final class GetFromDataBagTest extends TestCase
 {
     private $dataBag;
 
+    public function invalidPathProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'non-existant' => ['invalidPath'],
+            'ends with .' => ['person.'],
+            'ends with . on subpath' => ['person.firstName.'],
+            'starting with .' => ['.person.firstName'],
+            'has ..' => ['person..firstName'],
+            'has .. and .' => ['person..firstName.'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidPathProvider
+     */
+    public function it_throws_exception_if_invalid_path_is_used_when_getting_data(string $path): void
+    {
+        $this->expectException(InvalidDataBagPathException::class);
+        $this->dataBag->get($path);
+    }
+
+    public function getProvider(): array
+    {
+        return [
+            ['not.existing', 'default'],
+            ['person.firstName', 'John'],
+            ['person.emailAddresses.0', ['emailAddress' => 'john@doe.com', 'type' => 'private']],
+            ['person.emailAddresses.0.emailAddress', 'john@doe.com'],
+            ['person.emailAddresses.privateGsm.emailAddress', 'john@doe2.com'],
+            ['person.addresses.test', 'default'],
+            ['person.emailAddresses.test', 'default'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider getProvider
+     * @param array|string $expected
+     */
+    public function it_can_get_data_using_a_path(string $path, $expected): void
+    {
+        self::assertEquals($expected, $this->dataBag->get($path, 'default'));
+    }
+
     protected function setUp(): void
     {
         $personData = [
@@ -38,49 +84,5 @@ final class GetFromDataBagTest extends TestCase
     protected function tearDown(): void
     {
         unset($this->dataBag);
-    }
-
-    public function invalidPathProvider(): array
-    {
-        return [
-            'empty' => [''],
-            'non-existant' => ['invalidPath'],
-            'ends with .' => ['person.'],
-            'ends with . on subpath' => ['person.firstName.'],
-            'starting with .' => ['.person.firstName'],
-            'has ..' => ['person..firstName'],
-            'has .. and .' => ['person..firstName.'],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidPathProvider
-     */
-    public function testInvalidPath(string $path): void
-    {
-        $this->expectException(InvalidDataBagPathException::class);
-        $this->dataBag->get($path);
-    }
-
-    public function provider(): array
-    {
-        return [
-            ['not.existing', 'default'],
-            ['person.firstName', 'John'],
-            ['person.emailAddresses.0', ['emailAddress' => 'john@doe.com', 'type' => 'private']],
-            ['person.emailAddresses.0.emailAddress', 'john@doe.com'],
-            ['person.emailAddresses.privateGsm.emailAddress', 'john@doe2.com'],
-            ['person.addresses.test', 'default'],
-            ['person.emailAddresses.test', 'default'],
-        ];
-    }
-
-    /**
-     * @dataProvider provider
-     * @param array|string $expected
-     */
-    public function testDataBagGet(string $path, $expected): void
-    {
-        self::assertEquals($expected, $this->dataBag->get($path, 'default'));
     }
 }

--- a/tests/HasEntityDataTest.php
+++ b/tests/HasEntityDataTest.php
@@ -13,7 +13,25 @@ use PHPUnit\Framework\TestCase;
  */
 class HasEntityDataTest extends TestCase
 {
-    public function testHasEntityData(): void
+    private $dataBag;
+
+    /**
+     * @test
+     */
+    public function it_has_data_for_known_path(): void
+    {
+        self::assertTrue($this->dataBag->hasEntityData('person'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_have_data_for_known_path(): void
+    {
+        self::assertFalse($this->dataBag->hasEntityData('company'));
+    }
+
+    protected function setUp(): void
     {
         $personData = [
             'firstName' => 'John',
@@ -28,10 +46,12 @@ class HasEntityDataTest extends TestCase
                 ]
             ],
         ];
-        $dataBag = DataBag::create();
-        $dataBag->addEntityData('person', $personData);
+        $this->dataBag = DataBag::create();
+        $this->dataBag->addEntityData('person', $personData);
+    }
 
-        self::assertTrue($dataBag->hasEntityData('person'));
-        self::assertFalse($dataBag->hasEntityData('company'));
+    protected function tearDown(): void
+    {
+        unset($this->dataBag);
     }
 }

--- a/tests/IsDirtyTest.php
+++ b/tests/IsDirtyTest.php
@@ -8,13 +8,15 @@ use Communibase\DataBag;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class RemoveFromBag
- * @author Kingsquare (source@kingsquare.nl)
- * @copyright Copyright (c) Kingsquare BV (http://www.kingsquare.nl)
+ * Class IsDirtyTest
+ * @package Communibase\Tests
  */
 class IsDirtyTest extends TestCase
 {
-    public function testIsDirtyWhenFieldIsChanged(): void
+    /**
+     * @test
+     */
+    public function it_will_be_dirty_if_path_is_changed(): void
     {
         $personData = [
             'firstName' => 'John',
@@ -35,7 +37,10 @@ class IsDirtyTest extends TestCase
         self::assertTrue((bool)$dataBag->isDirty('person'));
     }
 
-    public function testIsDirtyWhenFieldIsUnchanged(): void
+    /**
+     * @test
+     */
+    public function it_will_not_be_dirty_if_path_is_unchanged(): void
     {
         $personData = [
             'firstName' => 'John',
@@ -56,7 +61,10 @@ class IsDirtyTest extends TestCase
         self::assertFalse((bool)$dataBag->isDirty('person'));
     }
 
-    public function testIsDirtyWhenRemovedFromBag(): void
+    /**
+     * @test
+     */
+    public function it_will_be_dirty_if_path_property_is_removed(): void
     {
         $personData = [
             'firstName' => 'John',
@@ -77,7 +85,10 @@ class IsDirtyTest extends TestCase
         self::assertTrue((bool)$dataBag->isDirty('person'));
     }
 
-    public function testIsDirtyWithUnknownPath(): void
+    /**
+     * @test
+     */
+    public function it_will_be_dirty_when_checking_unknown_path(): void
     {
         $personData = [
             'firstName' => 'John',
@@ -97,7 +108,10 @@ class IsDirtyTest extends TestCase
         self::assertNull($dataBag->isDirty('company'));
     }
 
-    public function testIsDirtyWitNewPath(): void
+    /**
+     * @test
+     */
+    public function it_will_be_dirty_when_adding_new_path(): void
     {
         $personData = [
             'firstName' => 'John',
@@ -118,7 +132,10 @@ class IsDirtyTest extends TestCase
         self::assertTrue((bool)$dataBag->isDirty('company'));
     }
 
-    public function test_generated_ids_are_ignored(): void
+    /**
+     * @test
+     */
+    public function generated_ids_are_ignored(): void
     {
         $dataBag = DataBag::create();
         $dataBag->addEntityData(

--- a/tests/RemoveFromBagTest.php
+++ b/tests/RemoveFromBagTest.php
@@ -14,29 +14,18 @@ use PHPUnit\Framework\TestCase;
  */
 class RemoveFromBagTest extends TestCase
 {
-    private $dataBag;
     private static $data = ['a' => 1, 'b' => [['type' => 'f', 'c' => 2], ['type' => 's', 'c' => 3], ['type' => 't']]];
+    private $dataBag;
 
-    protected function setUp(): void
-    {
-        $this->dataBag = DataBag::create();
-        $this->dataBag->addEntityData('foo', self::$data);
-    }
-
-    protected function tearDown(): void
-    {
-        unset($this->dataBag);
-    }
-
-    public function testInvalidPath(): void
+    /**
+     * @test
+     */
+    public function it_will_throw_exception_if_using_invalid_path(): void
     {
         $this->expectException(InvalidDataBagPathException::class);
         $this->dataBag->remove('invalidPath');
     }
 
-    /**
-     * @return array
-     */
     public function provider(): array
     {
         return [
@@ -55,15 +44,19 @@ class RemoveFromBagTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider provider
      */
-    public function testDataBagRemove(string $path, array $expected): void
+    public function it_will_remove_items(string $path, array $expected): void
     {
         $this->dataBag->remove($path);
         self::assertEquals($expected, $this->dataBag->getState());
     }
 
-    public function testDoNotRemoveAllOnNumericIndex(): void
+    /**
+     * @test
+     */
+    public function it_will_not_remove_all_items_if_numerically_indexed(): void
     {
         $this->dataBag->remove('foo.b.0', false);
         self::assertEquals(
@@ -72,7 +65,10 @@ class RemoveFromBagTest extends TestCase
         );
     }
 
-    public function test_property_becomes_null_if_empty(): void
+    /**
+     * @test
+     */
+    public function property_becomes_null_if_empty(): void
     {
         $dataBag = DataBag::fromEntityData(
             'foo',
@@ -82,5 +78,16 @@ class RemoveFromBagTest extends TestCase
         );
         $dataBag->remove('foo.a.b');
         self::assertEquals(['a' => null], $dataBag->getState('foo'));
+    }
+
+    protected function setUp(): void
+    {
+        $this->dataBag = DataBag::create();
+        $this->dataBag->addEntityData('foo', self::$data);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->dataBag);
     }
 }

--- a/tests/SetInBagTest.php
+++ b/tests/SetInBagTest.php
@@ -10,36 +10,26 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class SetInBagTest
- * @author Kingsquare (source@kingsquare.nl)
- * @copyright Copyright (c) Kingsquare BV (http://www.kingsquare.nl)
+ * @package Communibase\Tests
  */
 class SetInBagTest extends TestCase
 {
     private $emptyDataBag;
     private $filledDataBag;
 
-    protected function setUp(): void
-    {
-        $this->emptyDataBag = DataBag::create();
-        $this->filledDataBag = DataBag::create();
-        $this->filledDataBag->addEntityData(
-            'foo',
-            ['a' => 1, 'b' => [['type' => 'f', 'c' => 2], ['type' => 's', 'c' => 3]]]
-        );
-    }
-
-    protected function tearDown(): void
-    {
-        unset($this->emptyDataBag, $this->filledDataBag);
-    }
-
-    public function testRemoveBySettingNull(): void
+    /**
+     * @test
+     */
+    public function it_will_remove_a_value_by_issuing_null(): void
     {
         $this->filledDataBag->set('foo.a', null);
         self::assertNull($this->filledDataBag->getState('foo')['a']);
     }
 
-    public function testInvalidPath(): void
+    /**
+     * @test
+     */
+    public function it_throws_exception_if_invalid_path_is_used_when_setting_data(): void
     {
         $this->expectException(InvalidDataBagPathException::class);
         $this->emptyDataBag->set('invalidPath', 1);
@@ -58,10 +48,11 @@ class SetInBagTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider emptyDataBagProvider
      * @param int|array $value
      */
-    public function testEmptyDataBagSet(string $path, $value, array $expected): void
+    public function it_will_fill_empty_databag_with_various_contents(string $path, $value, array $expected): void
     {
         $this->emptyDataBag->set($path, $value);
         self::assertEquals($expected, $this->emptyDataBag->getState());
@@ -114,10 +105,11 @@ class SetInBagTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider filledDataBagProvider
      * @param array|string $value
      */
-    public function testFilledDataBagSet(string $path, $value, array $expected): void
+    public function it_will_fill_non_empty_databag_with_various_contents(string $path, $value, array $expected): void
     {
         $this->filledDataBag->set($path, $value);
         self::assertEquals($expected, $this->filledDataBag->getState());
@@ -134,5 +126,20 @@ class SetInBagTest extends TestCase
             ['addresses' => [[], ['type' => 'private', 'street' => 'bar']]],
             $dataBag->getState('foo')
         );
+    }
+
+    protected function setUp(): void
+    {
+        $this->emptyDataBag = DataBag::create();
+        $this->filledDataBag = DataBag::create();
+        $this->filledDataBag->addEntityData(
+            'foo',
+            ['a' => 1, 'b' => [['type' => 'f', 'c' => 2], ['type' => 's', 'c' => 3]]]
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->emptyDataBag, $this->filledDataBag);
     }
 }


### PR DESCRIPTION
Some of the test were snake_cased while others were camelCased. This is odd. I aligned them and also moved the structure a bit to be consistent across tests. (teardowns et al)

Signed-off-by: Robin Speekenbrink <robin@kingsquare.nl>