### PR TITLE
feat: use latest phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8",
-    "phpstan/phpstan-shim": "^0.11.8"
+    "phpstan/phpstan": "^0.12.51"
   }
 }


### PR DESCRIPTION
Upgrade the phpstan/phpstan-shim to full phpstan (and the latest version)

Currently up to level5 is 100%, but level 6 requires some more typings.

Signed-off-by: Robin Speekenbrink <robin@kingsquare.nl>