### PR TITLE
refactor: move data logic to separate mutator classes

### DIFF
--- a/src/DataBag.php
+++ b/src/DataBag.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Communibase;
 
+use Communibase\DataBag\DataMutator;
+use Communibase\DataBag\DataRemover;
+use Communibase\DataBag\DataRetriever;
+
 /**
  * It's a bag, for CB data. If we need to create a CB object from CB data (array) we can use this dataBag object as a
  * private entity class property. The dataBag can contain one or more entities. For each entity we can get/set
@@ -18,7 +22,22 @@ final class DataBag
      * The bag!
      * @var array<string, array>
      */
-    private $data;
+    private $data = [];
+
+    /**
+     * @var DataMutator
+     */
+    private $dataMutator;
+
+    /**
+     * @var DataRetriever
+     */
+    private $dataRetriever;
+
+    /**
+     * @var DataRemover;
+     */
+    private $dataRemover;
 
     /**
      * Original data hash for isDirty check
@@ -39,6 +58,9 @@ final class DataBag
      */
     private function __construct()
     {
+        $this->dataMutator = new DataMutator();
+        $this->dataRetriever = new DataRetriever();
+        $this->dataRemover = new DataRemover();
     }
 
     public static function create(): DataBag
@@ -51,7 +73,7 @@ final class DataBag
      */
     public static function fromEntityData(string $entityType, array $data): DataBag
     {
-        $dataBag = new self();
+        $dataBag = self::create();
         $dataBag->addEntityData($entityType, $data);
         return $dataBag;
     }
@@ -79,75 +101,6 @@ final class DataBag
      * @param string $path path to the target
      * @param mixed $default return value if there's no data
      *
-     * @return mixed
-     */
-    private function getByPath(string $path, $default = null)
-    {
-        [$entityType, $path] = explode('.', $path, 2);
-
-        // Direct property
-        if (strpos($path, '.') === false) {
-            return $this->data[$entityType][$path] ?? $default;
-        }
-
-        // Indexed
-        [$path, $index] = explode('.', $path, 2);
-
-        if (empty($this->data[$entityType][$path])) {
-            return $default;
-        }
-
-        return $this->getIndexed((array)$this->data[$entityType][$path], $index, $default);
-    }
-
-    /**
-     * @param array<string,array> $nodes
-     * @param mixed $default
-     *
-     * @return mixed
-     */
-    private function getIndexed(array $nodes, string $index, $default)
-    {
-        $field = null;
-        if (strpos($index, '.') > 0) {
-            [$index, $field] = explode('.', $index, 2);
-        }
-
-        $translatedIndex = $index;
-
-        if (!is_numeric($index)) {
-            $translatedIndex = null;
-            foreach ($nodes as $nodeIndex => $node) {
-                if (isset($node['type']) && $node['type'] === $index) {
-                    $translatedIndex = $nodeIndex;
-                    break;
-                }
-            }
-        }
-
-        if ($translatedIndex === null) {
-            return $default;
-        }
-
-        if ($field === null) {
-            return $nodes[$translatedIndex] ?? $default;
-        }
-
-        return $nodes[$translatedIndex][$field] ?? $default;
-    }
-
-    /**
-     * Fetch a cached value from the databag.
-     *
-     * $path can be:
-     * - person.firstName               direct property
-     * - person.emailAddresses.0        indexed by numeric position
-     * - person.addresses.visit         indexed by 'type' property
-     * - person.addresses.visit.street  indexed by 'type' property + get specific property
-     *
-     * @param string $path path to the target
-     * @param mixed $default return value if there's no data
-     *
      * @return mixed|null
      * @throws InvalidDataBagPathException
      */
@@ -156,7 +109,7 @@ final class DataBag
         $this->guardAgainstInvalidPath($path);
 
         if (!\array_key_exists($path, $this->cache)) {
-            $this->cache[$path] = $this->getByPath($path, $default);
+            $this->cache[$path] = $this->dataRetriever->getByPath($this->data, $path, $default);
         }
         return $this->cache[$path];
     }
@@ -176,88 +129,12 @@ final class DataBag
         unset($this->cache[$path]);
 
         if ($value === null) {
-            $this->remove($path);
+            $this->guardAgainstInvalidPath($path);
+            $this->dataRemover->remove($this->data, $path);
             return;
         }
 
-        $this->setByPath($path, $value);
-    }
-
-    /**
-     * @param mixed $value
-     */
-    private function setByPath(string $path, $value): void
-    {
-        [$entityType, $path] = explode('.', $path, 2);
-
-        // Direct property
-        if (strpos($path, '.') === false) {
-            $this->data[$entityType][$path] = $value;
-            return;
-        }
-
-        // Indexed
-        $this->setIndexed($entityType, $path, $value);
-    }
-
-    /**
-     * @param mixed $value
-     */
-    private function setIndexed(string $entityType, string $path, $value): void
-    {
-        [$path, $index] = explode('.', $path, 2);
-
-        $field = null;
-        if (strpos($index, '.') > 0) {
-            [$index, $field] = explode('.', $index, 2);
-        }
-
-        $target = $index;
-        if (!is_numeric($index)) {
-            if (\is_array($value)) {
-                $value['type'] = $index;
-            }
-            $index = null;
-            if (isset($this->data[$entityType][$path])) {
-                foreach ((array)$this->data[$entityType][$path] as $nodeIndex => $node) {
-                    if (isset($node['type']) && $node['type'] === $target) {
-                        $index = $nodeIndex;
-                        break;
-                    }
-                }
-            }
-        }
-
-        // No index found, new entry
-        if ($index === null) {
-            $this->addNewEntry($entityType, $path, $field, $target, $value);
-            return;
-        }
-
-        // Use found index
-        if ($field === null) {
-            $this->data[$entityType][$path][$index] = $value;
-            return;
-        }
-        $this->data[$entityType][$path][$index][$field] = $value;
-    }
-
-    /**
-     * @param mixed $value
-     */
-    private function addNewEntry(string $entityType, string $path, ?string $field, string $target, $value): void
-    {
-        if ($field === null) {
-            $this->data[$entityType][$path][] = $value;
-            return;
-        }
-        $value = [
-            $field => $value
-        ];
-        if (!is_numeric($target)) {
-            $value['type'] = $target;
-        }
-        $this->data[$entityType][$path][] = $value;
+        $this->dataMutator->setByPath($this->data, $path, $value);
     }
 
     /**
@@ -268,73 +145,6 @@ final class DataBag
     public function hasEntityData(string $entityType): bool
     {
         return isset($this->data[$entityType]);
-    }
-
-    /**
-     * Remove a property from the bag.
-     *
-     * @param string $path path to the target (see get() for examples)
-     * @param bool $removeAll remove all when the index is numeric (to prevent a new value after re-indexing)
-     *
-     * @throws InvalidDataBagPathException
-     */
-    public function remove(string $path, $removeAll = true): void
-    {
-        $this->guardAgainstInvalidPath($path);
-
-        [$entityType, $path] = explode('.', $path, 2);
-
-        // Direct property
-        if (strpos($path, '.') === false) {
-            if (!isset($this->data[$entityType][$path])) {
-                return;
-            }
-            $this->data[$entityType][$path] = null;
-            return;
-        }
-
-        $this->removeIndexed($path, $entityType, $removeAll);
-    }
-
-    private function removeIndexed(string $path, string $entityType, bool $removeAll): void
-    {
-        [$path, $index] = explode('.', $path);
-
-        // Target doesn't exist, nothing to remove
-        if (empty($this->data[$entityType][$path])) {
-            return;
-        }
-
-        if (is_numeric($index)) {
-            $index = (int)$index;
-            if ($removeAll) {
-                // Remove all (higher) values to prevent a new value after re-indexing
-                if ($index === 0) {
-                    $this->data[$entityType][$path] = null;
-                    return;
-                }
-                $this->data[$entityType][$path] = \array_slice($this->data[$entityType][$path], 0, $index);
-                return;
-            }
-            unset($this->data[$entityType][$path][$index]);
-        } else {
-            // Filter out all nodes of the specified type
-            $this->data[$entityType][$path] = array_filter(
-                $this->data[$entityType][$path],
-                static function ($node) use ($index) {
-                    return empty($node['type']) || $node['type'] !== $index;
-                }
-            );
-        }
-
-        // If we end up with an empty array make it NULL
-        if (empty($this->data[$entityType][$path])) {
-            $this->data[$entityType][$path] = null;
-            return;
-        }
-
-        // Re-index
-        $this->data[$entityType][$path] = array_values($this->data[$entityType][$path]);
     }
 
     /**

--- a/src/DataBag.php
+++ b/src/DataBag.php
@@ -130,7 +130,7 @@ final class DataBag
 
         if ($value === null) {
             $this->guardAgainstInvalidPath($path);
-            $this->dataRemover->remove($this->data, $path);
+            $this->dataRemover->removeByPath($this->data, $path);
             return;
         }
 

--- a/src/DataBag/DataMutator.php
+++ b/src/DataBag/DataMutator.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Communibase\DataBag;
+
+final class DataMutator
+{
+    /**
+     * @var array<string,array>
+     */
+    private $data;
+
+    /**
+     * @param mixed $value
+     */
+    public function setByPath(array &$data, string $path, $value): void
+    {
+        $this->data = &$data;
+
+        [$entityType, $path] = explode('.', $path, 2);
+
+        // Direct property
+        if (strpos($path, '.') === false) {
+            $data[$entityType][$path] = $value;
+            return;
+        }
+
+        // Indexed
+        $this->setIndexed($entityType, $path, $value);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function setIndexed(string $entityType, string $path, $value): void
+    {
+        [$path, $index] = explode('.', $path, 2);
+
+        $field = null;
+        if (strpos($index, '.') > 0) {
+            [$index, $field] = explode('.', $index, 2);
+        }
+
+        $target = $index;
+        if (!is_numeric($index)) {
+            if (\is_array($value)) {
+                $value['type'] = $index;
+            }
+            $index = null;
+            if (isset($this->data[$entityType][$path])) {
+                foreach ((array)$this->data[$entityType][$path] as $nodeIndex => $node) {
+                    if (isset($node['type']) && $node['type'] === $target) {
+                        $index = $nodeIndex;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // No index found, new entry
+        if ($index === null) {
+            $this->addNewEntry($entityType, $path, $field, $target, $value);
+            return;
+        }
+
+        // Use found index
+        if ($field === null) {
+            $this->data[$entityType][$path][$index] = $value;
+            return;
+        }
+        $this->data[$entityType][$path][$index][$field] = $value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function addNewEntry(string $entityType, string $path, ?string $field, string $target, $value): void
+    {
+        if ($field === null) {
+            $this->data[$entityType][$path][] = $value;
+            return;
+        }
+        $value = [
+            $field => $value
+        ];
+        if (!is_numeric($target)) {
+            $value['type'] = $target;
+        }
+        $this->data[$entityType][$path][] = $value;
+    }
+}

--- a/src/DataBag/DataRemover.php
+++ b/src/DataBag/DataRemover.php
@@ -18,7 +18,7 @@ final class DataRemover
      *
      * @throws InvalidDataBagPathException
      */
-    public function remove(array &$data, string $path): void
+    public function removeByPath(array &$data, string $path): void
     {
         $this->data = &$data;
 

--- a/src/DataBag/DataRemover.php
+++ b/src/DataBag/DataRemover.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Communibase\DataBag;
+
+final class DataRemover
+{
+    /**
+     * @var array<string,array>
+     */
+    private $data;
+
+    /**
+     * Remove a property from the bag.
+     *
+     * @param string $path path to the target (see get() for examples)
+     *
+     * @throws InvalidDataBagPathException
+     */
+    public function remove(array &$data, string $path): void
+    {
+        $this->data = &$data;
+
+        [$entityType, $path] = explode('.', $path, 2);
+
+        // Direct property
+        if (strpos($path, '.') === false) {
+            if (!isset($this->data[$entityType][$path])) {
+                return;
+            }
+            $data[$entityType][$path] = null;
+            return;
+        }
+
+        $this->removeIndexed($path, $entityType);
+    }
+
+    private function removeIndexed(string $path, string $entityType): void
+    {
+        [$path, $index] = explode('.', $path);
+
+        // Target doesn't exist, nothing to remove
+        if (empty($this->data[$entityType][$path])) {
+            return;
+        }
+
+        if (is_numeric($index)) {
+            $index = (int)$index;
+            // Remove all (higher) values to prevent a new value after re-indexing
+            if ($index === 0) {
+                $this->data[$entityType][$path] = null;
+                return;
+            }
+            $this->data[$entityType][$path] = \array_slice($this->data[$entityType][$path], 0, $index);
+            return;
+        }
+
+        // Filter out all nodes of the specified type
+        $this->data[$entityType][$path] = array_filter(
+            $this->data[$entityType][$path],
+            static function ($node) use ($index) {
+                return empty($node['type']) || $node['type'] !== $index;
+            }
+        );
+
+        // If we end up with an empty array make it NULL
+        if (empty($this->data[$entityType][$path])) {
+            $this->data[$entityType][$path] = null;
+            return;
+        }
+
+        // Re-index
+        $this->data[$entityType][$path] = array_values($this->data[$entityType][$path]);
+    }
+}

--- a/src/DataBag/DataRetriever.php
+++ b/src/DataBag/DataRetriever.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Communibase\DataBag;
+
+final class DataRetriever
+{
+    /**
+     * @param array<string,array> $data
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getByPath(array $data, string $path, $default = null)
+    {
+        [$entityType, $path] = explode('.', $path, 2);
+
+        // Direct property
+        if (strpos($path, '.') === false) {
+            return $data[$entityType][$path] ?? $default;
+        }
+
+        // Indexed
+        [$property, $index] = explode('.', $path, 2);
+
+        if (empty($data[$entityType][$property])) {
+            return $default;
+        }
+
+        return $this->getIndexedValue((array)$data[$entityType][$property], $index, $default);
+    }
+
+    /**
+     * @param array<string,array> $properties
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    private function getIndexedValue(array $properties, string $index, $default)
+    {
+        $targetProperty = null;
+        if (strpos($index, '.') > 0) {
+            [$index, $targetProperty] = explode('.', $index, 2);
+        }
+
+        $translatedIndex = $index;
+
+        if (!is_numeric($index)) {
+            $translatedIndex = null;
+            foreach ($properties as $nodeIndex => $node) {
+                if (isset($node['type']) && $node['type'] === $index) {
+                    $translatedIndex = $nodeIndex;
+                    break;
+                }
+            }
+        }
+
+        if ($translatedIndex === null) {
+            return $default;
+        }
+
+        if ($targetProperty === null) {
+            return $properties[$translatedIndex] ?? $default;
+        }
+
+        return $properties[$translatedIndex][$targetProperty] ?? $default;
+    }
+}

--- a/tests/IsDirtyTest.php
+++ b/tests/IsDirtyTest.php
@@ -65,7 +65,7 @@ class IsDirtyTest extends TestCase
             ],
         ];
         $dataBag = DataBag::fromEntityData('person', $personData);
-        $dataBag->remove('person.firstName', true);
+        $dataBag->set('person.firstName', null);
         self::assertTrue((bool)$dataBag->isDirty('person'));
     }
 

--- a/tests/RemoveFromBagTest.php
+++ b/tests/RemoveFromBagTest.php
@@ -33,7 +33,7 @@ class RemoveFromBagTest extends TestCase
     public function test_it_will_throw_exception_if_using_invalid_path(): void
     {
         $this->expectException(InvalidDataBagPathException::class);
-        $this->dataBag->remove('invalidPath');
+        $this->dataBag->set('invalidPath', null);
     }
 
     /**
@@ -62,17 +62,8 @@ class RemoveFromBagTest extends TestCase
      */
     public function test_it_will_remove_items(string $path, array $expected): void
     {
-        $this->dataBag->remove($path);
+        $this->dataBag->set($path, null);
         self::assertEquals($expected, $this->dataBag->getState());
-    }
-
-    public function test_it_will_not_remove_all_items_if_numerically_indexed(): void
-    {
-        $this->dataBag->remove('foo.b.0', false);
-        self::assertEquals(
-            ['foo' => ['a' => 1, 'b' => [['type' => 's', 'c' => 3], ['type' => 't']]]],
-            $this->dataBag->getState()
-        );
     }
 
     public function test_property_becomes_null_if_empty(): void
@@ -83,7 +74,7 @@ class RemoveFromBagTest extends TestCase
                 'a' => [['type' => 'b'], ['type' => 'b']]
             ]
         );
-        $dataBag->remove('foo.a.b');
+        $dataBag->set('foo.a.b', null);
         self::assertEquals(['a' => null], $dataBag->getState('foo'));
     }
 }


### PR DESCRIPTION
Removed 'not remove all if numerically indexed' test / code because this was faulty behaviour. It makes no sense to shift data if the array is numerically used.

Extracting logic to mutator classes has a speed penalty but it's ignorable. If we create a DataBag with data and set, get and remove a property once 100.000 times the overhead is ~150ms on ~4sec (0.0375%).

Scrutinizer likes it, 6.57 -> 9.68
