### PR TITLE
feat: add sub-path support to mutator and retriever

### DIFF
--- a/src/DataBag/DataMutator.php
+++ b/src/DataBag/DataMutator.php
@@ -29,7 +29,7 @@ final class DataMutator
         [$path, $index] = explode('.', $path, 2);
 
         // Sub-path
-        if (!\is_array($value) && !\is_numeric($index) && \strpos($index, '.') === false) {
+        if (!is_numeric($index) && strpos($index, '.') === false && !$this->isAssocativeArray($value)) {
             $this->data[$entityType][$path][$index] = $value;
             return;
         }
@@ -93,5 +93,13 @@ final class DataMutator
             $value['type'] = $target;
         }
         $this->data[$entityType][$path][] = $value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function isAssocativeArray($value): bool
+    {
+        return \is_array($value) && (array_keys($value) !== range(0, \count($value) - 1));
     }
 }

--- a/src/DataBag/DataMutator.php
+++ b/src/DataBag/DataMutator.php
@@ -26,32 +26,37 @@ final class DataMutator
             return;
         }
 
-        // Indexed
-        $this->setIndexed($entityType, $path, $value);
+        [$path, $index] = explode('.', $path, 2);
+
+        // Sub-path
+        if (!\is_array($value) && !\is_numeric($index) && \strpos($index, '.') === false) {
+            $this->data[$entityType][$path][$index] = $value;
+            return;
+        }
+
+        $this->setIndexed($entityType, $path, $index, $value);
     }
 
     /**
      * @param mixed $value
      */
-    private function setIndexed(string $entityType, string $path, $value): void
+    private function setIndexed(string $entityType, string $path, string $index, $value): void
     {
-        [$path, $index] = explode('.', $path, 2);
-
         $field = null;
         if (strpos($index, '.') > 0) {
             [$index, $field] = explode('.', $index, 2);
         }
 
-        $target = $index;
-        if (!is_numeric($index)) {
+        $targetIndex = $index;
+        if (!is_numeric($targetIndex)) {
             if (\is_array($value)) {
-                $value['type'] = $index;
+                $value['type'] = $targetIndex;
             }
-            $index = null;
+            $targetIndex = null;
             if (isset($this->data[$entityType][$path])) {
                 foreach ((array)$this->data[$entityType][$path] as $nodeIndex => $node) {
-                    if (isset($node['type']) && $node['type'] === $target) {
-                        $index = $nodeIndex;
+                    if (isset($node['type']) && $node['type'] === $index) {
+                        $targetIndex = $nodeIndex;
                         break;
                     }
                 }
@@ -59,17 +64,17 @@ final class DataMutator
         }
 
         // No index found, new entry
-        if ($index === null) {
-            $this->addNewEntry($entityType, $path, $field, $target, $value);
+        if ($targetIndex === null) {
+            $this->addNewEntry($entityType, $path, $field, $index, $value);
             return;
         }
 
         // Use found index
         if ($field === null) {
-            $this->data[$entityType][$path][$index] = $value;
+            $this->data[$entityType][$path][$targetIndex] = $value;
             return;
         }
-        $this->data[$entityType][$path][$index][$field] = $value;
+        $this->data[$entityType][$path][$targetIndex][$field] = $value;
     }
 
     /**

--- a/src/DataBag/DataRemover.php
+++ b/src/DataBag/DataRemover.php
@@ -33,11 +33,6 @@ final class DataRemover
             return;
         }
 
-        $this->removeIndexed($path, $entityType);
-    }
-
-    private function removeIndexed(string $path, string $entityType): void
-    {
         [$path, $index] = explode('.', $path);
 
         // Target doesn't exist, nothing to remove
@@ -45,14 +40,24 @@ final class DataRemover
             return;
         }
 
+        // Sub-path
+        if (isset($this->data[$entityType][$path][$index]) && !is_numeric($index) && strpos($index, '.') === false) {
+            $this->data[$entityType][$path][$index] = null;
+            return;
+        }
+
+        $this->removeIndexed($entityType, $path, $index);
+    }
+
+    private function removeIndexed(string $entityType, string $path, string $index): void
+    {
         if (is_numeric($index)) {
-            $index = (int)$index;
             // Remove all (higher) values to prevent a new value after re-indexing
-            if ($index === 0) {
+            if ((int)$index === 0) {
                 $this->data[$entityType][$path] = null;
                 return;
             }
-            $this->data[$entityType][$path] = \array_slice($this->data[$entityType][$path], 0, $index);
+            $this->data[$entityType][$path] = \array_slice($this->data[$entityType][$path], 0, (int)$index);
             return;
         }
 

--- a/src/DataBag/DataRetriever.php
+++ b/src/DataBag/DataRetriever.php
@@ -21,13 +21,18 @@ final class DataRetriever
             return $data[$entityType][$path] ?? $default;
         }
 
-        // Indexed
         [$property, $index] = explode('.', $path, 2);
 
         if (empty($data[$entityType][$property])) {
             return $default;
         }
 
+        // Sub-path
+        if (\is_string($index) && \array_key_exists($index, $data[$entityType][$property])) {
+            return $data[$entityType][$property][$index] ?? $default;
+        }
+
+        // Indexed
         return $this->getIndexedValue((array)$data[$entityType][$property], $index, $default);
     }
 

--- a/tests/GetFromDataBagTest.php
+++ b/tests/GetFromDataBagTest.php
@@ -29,6 +29,7 @@ final class GetFromDataBagTest extends TestCase
                     'type' => 'privateGsm',
                 ]
             ],
+            'metadata' => ['path' => 'Foo']
         ];
         $this->dataBag = DataBag::fromEntityData('person', $personData);
     }
@@ -70,12 +71,14 @@ final class GetFromDataBagTest extends TestCase
     {
         return [
             ['not.existing', 'default'],
+            ['not.existing.subPath', 'default'],
             ['person.firstName', 'John'],
             ['person.emailAddresses.0', ['emailAddress' => 'john@doe.com', 'type' => 'private']],
             ['person.emailAddresses.0.emailAddress', 'john@doe.com'],
             ['person.emailAddresses.privateGsm.emailAddress', 'john@doe2.com'],
             ['person.addresses.test', 'default'],
             ['person.emailAddresses.test', 'default'],
+            ['person.metadata.path', 'Foo'],
         ];
     }
 

--- a/tests/RemoveFromBagTest.php
+++ b/tests/RemoveFromBagTest.php
@@ -77,4 +77,19 @@ class RemoveFromBagTest extends TestCase
         $dataBag->set('foo.a.b', null);
         self::assertEquals(['a' => null], $dataBag->getState('foo'));
     }
+
+    public function test_it_can_remove_a_sub_path(): void
+    {
+        $dataBag = DataBag::fromEntityData(
+            'foo',
+            [
+                'a' => 1,
+                'b' => ['c' => 2],
+                'd' => ['e' => [1, 2]]
+            ]
+        );
+        $dataBag->set('foo.b.c', null);
+        $dataBag->set('foo.d.e', null);
+        self::assertSame(['a' => 1, 'b' => ['c' => null], 'd' => ['e' => null]], $dataBag->getState('foo'));
+    }
 }

--- a/tests/SetInBagTest.php
+++ b/tests/SetInBagTest.php
@@ -54,7 +54,7 @@ class SetInBagTest extends TestCase
         return [
             ['foo.bar', 1, ['foo' => ['bar' => 1]]],
             ['foo.bar.0', 1, ['foo' => ['bar' => [1]]]],
-            ['foo.bar.test', 1, ['foo' => ['bar' => [1]]]],
+            ['foo.bar.test', 1, ['foo' => ['bar' => ['test' => 1]]]],
             ['foo.bar.test', ['baz' => 3], ['foo' => ['bar' => [['baz' => 3, 'type' => 'test']]]]],
             ['foo.bar.0.baz', 1, ['foo' => ['bar' => [['baz' => 1]]]]],
             ['foo.bar.test.baz', 1, ['foo' => ['bar' => [['baz' => 1, 'type' => 'test']]]]],
@@ -101,7 +101,7 @@ class SetInBagTest extends TestCase
             [
                 'foo.b.s',
                 2,
-                ['foo' => ['a' => 1, 'b' => [['type' => 'f', 'c' => 2], 2]]]
+                ['foo' => ['a' => 1, 'b' => [['type' => 'f', 'c' => 2], ['type' => 's', 'c' => 3], 's' => 2]]]
             ],
             [
                 'foo.b.s',

--- a/tests/SetInBagTest.php
+++ b/tests/SetInBagTest.php
@@ -58,6 +58,7 @@ class SetInBagTest extends TestCase
             ['foo.bar.test', ['baz' => 3], ['foo' => ['bar' => [['baz' => 3, 'type' => 'test']]]]],
             ['foo.bar.0.baz', 1, ['foo' => ['bar' => [['baz' => 1]]]]],
             ['foo.bar.test.baz', 1, ['foo' => ['bar' => [['baz' => 1, 'type' => 'test']]]]],
+            ['foo.bar.test', [1, 2], ['foo' => ['bar' => ['test' => [1, 2]]]]],
         ];
     }
 


### PR DESCRIPTION
Add support for sub-paths (e.g. 'file.metaData.path'). Should not conflict with indexed paths e.g. 'person.addresses.0' or 'person.addresses.private'. The former has a numerical index and is thereby ignored, the latter is not as straightforward. When retrieving data we check if the index ('path') exists on the property ('metaData'). Indexed properties should always be non-associative array and thus there is no match. When setting data we can check the value. If the value is an associative array we must assume it's an indexed path and process it as such. Hence it is not possible to use an associative array as a value for a sub-path (but I don't think that's a common use case). 

Fixes #2